### PR TITLE
Retain chars with semantic or phrasing meaning

### DIFF
--- a/src/isomorphic-utils.ts
+++ b/src/isomorphic-utils.ts
@@ -117,14 +117,8 @@ export function dateToString(date?: Date): string {
  * XML special characters (&<>"') are handled by the escape() function.
  */
 export function removeIncompatibleCharacters(str: string): string {
-  // Keep essential punctuation for natural speech: .?;:!,
-  // Remove characters that could break SSML structure or cause parsing issues
-  const chars_to_remove = "*/()[]{}$%^@#+=|\\~`><\"&";
-  let clean_str = str;
-  for (const char of chars_to_remove) {
-    clean_str = clean_str.replace(new RegExp('\\' + char, 'g'), '');
-  }
-  return clean_str;
+  // Remove control characters except for \t, \n, \r
+  return str.replaceAll(/[\p{C}--[\t\r\n]]/gv, ' ');
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/travisvn/edge-tts-universal/issues/7

Manually tested with this input, spoken output is as expected with no errors:

```ts
const tts = new EdgeTTS(`1 < 2 & 6 > 5, a\x00b, c\x1fd, foo "bar 'baz'", one (two) three, x\ty\r\nend!`, 'en-GB-SoniaNeural')
new Audio(URL.createObjectURL((await tts.synthesize()).audio)).play()
```

[`/regex/v`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets) is baseline 2023, depending on minimum support requirements you might want to swap it out for a hard-coded list of control chars a-la [the version in `src/utils.ts`](https://github.com/travisvn/edge-tts-universal/blob/01659bc7097cc40be782038bea019fc98ab9f967/src/utils.ts#L55-L58).