### PR TITLE
Perform trim() on the text after it has been modified (travisvn#13)

### DIFF
--- a/src/browser-communicate.ts
+++ b/src/browser-communicate.ts
@@ -104,7 +104,7 @@ function browserGetHeadersAndDataFromBinary(message: Uint8Array): [{ [key: strin
 
 function browserSplitTextByByteLength(text: string, byteLength: number): Generator<Uint8Array> {
   return (function* () {
-    let buffer = new TextEncoder().encode(text);
+    let buffer = new TextEncoder().encode(text.trim());
 
     if (byteLength <= 0) {
       throw new Error("byteLength must be greater than 0");

--- a/src/isomorphic-utils.ts
+++ b/src/isomorphic-utils.ts
@@ -149,7 +149,7 @@ export function mkssml(tc: TTSConfig, escapedText: string | Uint8Array): string 
  */
 export function splitTextByByteLength(text: string, byteLength: number): string[] {
   const encoder = new TextEncoder();
-  const words = text.split(/(\s+)/); // Split by whitespace but keep delimiters
+  const words = text.trim().split(/(\s+)/); // Split by whitespace but keep delimiters
   const chunks: string[] = [];
   let currentChunk = "";
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -112,7 +112,10 @@ function _adjustSplitPointForXmlEntity(text: Buffer, splitAt: number): number {
  * @throws {ValueError} If byteLength is too small or text has invalid structure
  */
 export function* splitTextByByteLength(text: string | Buffer, byteLength: number): Generator<Buffer> {
-  let buffer = Buffer.isBuffer(text) ? text : Buffer.from(text, 'utf-8');
+  let buffer = Buffer.from(
+    (Buffer.isBuffer(text) ? text.toString('utf-8') : text).trim(),
+    'utf-8'
+  );
 
   if (byteLength <= 0) {
     throw new ValueError("byteLength must be greater than 0");


### PR DESCRIPTION
Perform a trim() on the text after deleting a chunk from it.

This solves issue #13.

If you don't clear the text in this example:

```js
import { EdgeTTS } from 'edge-tts-universal';
import fs from 'fs/promises';

const text = 'The next paragraph is longer than 4096 characters.\n' + 'Lorem Ipsum. '.repeat(320);

const tts = new EdgeTTS(text);
const result = await tts.synthesize();
const audioBuffer = Buffer.from(await result.audio.arrayBuffer());
await fs.writeFile('output.mp3', audioBuffer);
```

then after changing the text, an error occurs where the next chunk size is 0, and further processing is interrupted.