### PR TITLE
Perform trim() on the text after it has been modified (#13)

### DIFF
--- a/src/browser-communicate.ts
+++ b/src/browser-communicate.ts
@@ -132,6 +132,7 @@ function browserSplitTextByByteLength(text: string, byteLength: number): Generat
       }
 
       buffer = buffer.slice(splitAt);
+      buffer = new TextEncoder().encode(new TextDecoder().decode(buffer).trim());
     }
 
     const remainingText = new TextDecoder().decode(buffer).trim();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -141,6 +141,7 @@ export function* splitTextByByteLength(text: string | Buffer, byteLength: number
     }
 
     buffer = buffer.subarray(splitAt);
+    buffer = Buffer.from(buffer.toString('utf-8').trim(), 'utf-8');
   }
 
   const remainingChunk = buffer.toString('utf-8').trim();


### PR DESCRIPTION
Perform a trim() on the text after deleting a chunk from it.

This solves issue #13.

If you don't clear the text in this example:

```js
import { EdgeTTS } from 'edge-tts-universal';
import fs from 'fs/promises';

const text = 'The next paragraph is longer than 4096 characters.\n' + 'Lorem Ipsum. '.repeat(320);

const tts = new EdgeTTS(text);
const result = await tts.synthesize();
const audioBuffer = Buffer.from(await result.audio.arrayBuffer());
await fs.writeFile('output.mp3', audioBuffer);
```

then after changing the text, an error occurs where the next chunk size is 0, and further processing is interrupted.