### PR TITLE
Update request headers

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,7 +14,7 @@ export const VOICE_LIST_URL = `https://${BASE_URL}/voices/list?trustedclienttoke
 export const DEFAULT_VOICE = "en-US-EmmaMultilingualNeural";
 
 /** Version string for Chromium browser emulation */
-export const CHROMIUM_FULL_VERSION = "130.0.2849.68";
+export const CHROMIUM_FULL_VERSION = "142.0.3595.94";
 
 /** Major version number extracted from the full Chromium version */
 export const CHROMIUM_MAJOR_VERSION = CHROMIUM_FULL_VERSION.split(".")[0];
@@ -41,7 +41,7 @@ export const WSS_HEADERS = {
 export const VOICE_HEADERS = {
   ...BASE_HEADERS,
   "Authority": "speech.platform.bing.com",
-  "Sec-CH-UA": `" Not;A Brand";v="99", "Microsoft Edge";v="${CHROMIUM_MAJOR_VERSION}", "Chromium";v="${CHROMIUM_MAJOR_VERSION}"`,
+  "Sec-CH-UA": `"Chromium";v="${CHROMIUM_MAJOR_VERSION}", "Microsoft Edge";v="${CHROMIUM_MAJOR_VERSION}", "Not_A Brand";v="99"`,
   "Sec-CH-UA-Mobile": "?0",
   "Accept": "*/*",
   "Sec-Fetch-Site": "none",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -35,6 +35,8 @@ export const WSS_HEADERS = {
   "Pragma": "no-cache",
   "Cache-Control": "no-cache",
   "Origin": "chrome-extension://jdiccldimpdaibmpdkjnbmckianbfold",
+  "Sec-WebSocket-Protocol": "synthesize",
+  "Sec-WebSocket-Version": "13",
 };
 
 /** HTTP headers specific to voice list API requests */

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,7 +14,7 @@ export const VOICE_LIST_URL = `https://${BASE_URL}/voices/list?trustedclienttoke
 export const DEFAULT_VOICE = "en-US-EmmaMultilingualNeural";
 
 /** Version string for Chromium browser emulation */
-export const CHROMIUM_FULL_VERSION = "142.0.3595.94";
+export const CHROMIUM_FULL_VERSION = "144.0.3719.92";
 
 /** Major version number extracted from the full Chromium version */
 export const CHROMIUM_MAJOR_VERSION = CHROMIUM_FULL_VERSION.split(".")[0];
@@ -42,7 +42,7 @@ export const WSS_HEADERS = {
 export const VOICE_HEADERS = {
   ...BASE_HEADERS,
   "Authority": "speech.platform.bing.com",
-  "Sec-CH-UA": `"Chromium";v="${CHROMIUM_MAJOR_VERSION}", "Microsoft Edge";v="${CHROMIUM_MAJOR_VERSION}", "Not_A Brand";v="99"`,
+  "Sec-CH-UA": `"Not(A:Brand";v="8", "Chromium";v="${CHROMIUM_MAJOR_VERSION}", "Microsoft Edge";v="${CHROMIUM_MAJOR_VERSION}"`,
   "Sec-CH-UA-Mobile": "?0",
   "Accept": "*/*",
   "Sec-Fetch-Site": "none",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,7 +25,7 @@ export const SEC_MS_GEC_VERSION = `1-${CHROMIUM_FULL_VERSION}`;
 /** Base HTTP headers for API requests, mimicking a real browser */
 export const BASE_HEADERS = {
   "User-Agent": `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${CHROMIUM_MAJOR_VERSION}.0.0.0 Safari/537.36 Edg/${CHROMIUM_MAJOR_VERSION}.0.0.0`,
-  "Accept-Encoding": "gzip, deflate, br",
+  "Accept-Encoding": "gzip, deflate, br, zstd",
   "Accept-Language": "en-US,en;q=0.9",
 };
 
@@ -35,7 +35,6 @@ export const WSS_HEADERS = {
   "Pragma": "no-cache",
   "Cache-Control": "no-cache",
   "Origin": "chrome-extension://jdiccldimpdaibmpdkjnbmckianbfold",
-  "Sec-WebSocket-Protocol": "synthesize",
   "Sec-WebSocket-Version": "13",
 };
 


### PR DESCRIPTION
- Update User-Agent headers to the current version
- Add missing Sec-WebSocket-Protocol and Sec-WebSocket-Version headers for WebSocket connections (similar to [rany2/edge-tts](https://github.com/rany2/edge-tts/blob/master/src/edge_tts/constants.py#L29))